### PR TITLE
Fixing snapshot creation output

### DIFF
--- a/client.go
+++ b/client.go
@@ -450,6 +450,14 @@ func (c *Client) GetPowerState(vm *VirtualMachine) (PowerState, error) {
 	return ps, nil
 }
 
+func (c *Client) ReportSnapshot(mo *types.ManagedObjectReference) *Snapshot {
+	s := &Snapshot{
+		Ref: mo.Reference().Value,
+	}
+
+	return s
+}
+
 // ReportVM writes descriptive JSON data to the console
 func (c *Client) ReportVM(vm *VirtualMachine) *VirtualMachineInfo {
 	d := &VirtualMachineInfo{

--- a/cmd/clientCommand.go
+++ b/cmd/clientCommand.go
@@ -151,6 +151,18 @@ func (cc *ClientCommand) readString(params []string) (string, error) {
 	return value, nil
 }
 
+func (cc *ClientCommand) writeSnapshotToConsole(snapshot *vcon.Snapshot) error {
+	bytes, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return fmt.Errorf("Failed to serialize to JSON")
+	}
+
+	os.Stdout.Write(bytes)
+	os.Stdout.WriteString("\n")
+
+	return nil
+}
+
 func (cc *ClientCommand) writeVMInfoToConsole(vm *vcon.VirtualMachine) error {
 	vmi := cc.c.ReportVM(vm)
 	bytes, err := json.MarshalIndent(vmi, "", "  ")

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -48,10 +48,13 @@ func createSnapshotCreateCommand() *cobra.Command {
 		}
 
 		name := cc.generateSnapshotName(name)
-		err = cc.c.SnapshotCreate(vm, name)
+		mo, err := cc.c.SnapshotCreate(vm, name)
 		if err != nil {
 			return err
 		}
+
+		snapshot := cc.c.ReportSnapshot(mo)
+		_ = cc.writeSnapshotToConsole(snapshot)
 
 		return nil
 	}


### PR DESCRIPTION
The `snapshot create` command had garbage-like output, such as 

``` sh 
Got snapshot: types.ManagedObjectReference{Type:"VirtualMachineSnapshot", Value:"snapshot-2107"}
```

This is not easily parsable; the output should be pure JSON.