### PR TITLE
Rename and move VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ if [[ $SUCCESS == 0 ]];
 	# Power destroy the VM
 	vcon destroy $TARGET --targetIsRef --force
 else
-  vcon relocate $TARGET --targetIsRef --destination "/Engineering/TeamSharks/Failed tests"
+	vcon relocate $TARGET --targetIsRef --destination "/Engineering/TeamSharks/Failed tests"
 	vcon note $TARGET "Test failed" --targetIsRef
 fi
 ```

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ vcon configure $TARGET /tmp/machine.json
 
 Using the `note` command, `vcon` can append a new piece of text to a VM in vSphere.  The `--overwrite` flag can be used to replace any existing notes.
 
+### Moving and renaming
+
+Using the `relocate` command, `vcon` can rename a VM and/or move it into a different folder.  The target location must still be in the same data store and data center.  Like the `clone` command, the name and destination are derived from `--name` and `--destination` (or `-n` and `-d`) options.  Unlike the `clone` command, there is no default for the name option, and for the destination, any value in a configuration file is ignored.
+
 ### Power cycling
 
 Using the `power` command, `vcon` can turn on, turn off, or suspend a VM.
@@ -128,14 +132,18 @@ The `vcon` CLI uses [Cobra](https://github.com/spf13/cobra) and [Viper](https://
 | verbose | v | (all) |  | Y | | `false` |
 | config | | (all) | | | | `~/.vcon.[json\|yaml]` |
 | configuration | c | clone | | | |
-| destination | d | clone | | Y | |
-| name | n | clone, snapsnot-create | | | | (generated) |
+| destination | d | clone, relocate | | Y (*) | |
+| name | n | clone, relocate, snapsnot-create | | | | (generated) (**) |
 | on | | clone | | | | `true` |
 | resourcepool | | clone | Y | Y | Y | |
 | force | f | destroy | | | | `false` |
 | overwrite | | note | | | | `false` |
 | snapshotIsRef| | snapshot-remove, snapshot-revert | | | | `false` |
 | targetIsRef | | configure, destroy, info, note, power, snapshot-* | | | | `false` |
+
+`*` The destination parameter for the `relocate` command is not taken from the config file
+
+`**` The name parameter is for the `relocate` command is not generated 
 
 ## Templates
 
@@ -243,6 +251,7 @@ if [[ $SUCCESS == 0 ]];
 	# Power destroy the VM
 	vcon destroy $TARGET --targetIsRef --force
 else
+  vcon relocate $TARGET --targetIsRef --destination "/Engineering/TeamSharks/Failed tests"
 	vcon note $TARGET "Test failed" --targetIsRef
 fi
 ```

--- a/client.go
+++ b/client.go
@@ -457,6 +457,61 @@ func (c *Client) GetPowerState(vm *VirtualMachine) (PowerState, error) {
 	return ps, nil
 }
 
+// Relocate will move the VM into a new destination folder, and/or change its
+// name
+func (c *Client) Relocate(vm *VirtualMachine, name, destination string) error {
+	err := func() error {
+		ctx, cancelFn := context.WithTimeout(context.Background(), c.timeout)
+		defer cancelFn()
+
+		if name != "" {
+			task, err := vm.VM.Rename(ctx, name)
+			_, err = c.finishTask(ctx, task, err)
+			if err = c.checkErr(ctx, err); err != nil {
+				return err
+			}
+		}
+
+		if destination != "" {
+			fmt.Printf("Have destination '%s'\n", destination)
+			inventoryDestination := c.makeInventoryPath(destination)
+			fmt.Printf("inventoryDestination: '%s'\n", inventoryDestination)
+			objFolder, err := c.Finder.Folder(ctx, inventoryDestination)
+			if err := c.checkErr(ctx, err); err != nil {
+				return errors.Wrapf(err, "While getting folder named '%s'", destination)
+			}
+
+			task, err := objFolder.MoveInto(ctx, []types.ManagedObjectReference{vm.Ref})
+
+			// vmrs := types.VirtualMachineRelocateSpec{}
+			// folderMoRef := objFolder.Reference()
+			// vmrs.Folder = &folderMoRef
+			// task, err := vm.VM.Relocate(ctx, vmrs, types.VirtualMachineMovePriorityDefaultPriority)
+			_, err = c.finishTask(ctx, task, err)
+			if err = c.checkErr(ctx, err); err != nil {
+				return err
+			}
+
+			fmt.Printf("Relocate complete\n")
+		}
+
+		return nil
+	}()
+
+	if err != nil {
+		switch err := errors.Cause(err).(type) {
+		case *TimeoutExceededError:
+			// handle specifically
+			return fmt.Errorf("Timeout while attempting to rename and/or move VM")
+		default:
+			// unknown error
+			return errors.Wrap(err, "Got error while attempting to rename and/or move VM")
+		}
+	}
+
+	return err
+}
+
 func (c *Client) ReportSnapshot(mo *types.ManagedObjectReference) *Snapshot {
 	s := &Snapshot{
 		Ref: mo.Reference().Value,

--- a/client.go
+++ b/client.go
@@ -18,7 +18,7 @@ import (
 )
 
 // Version is the version of the application and API
-const Version = "0.3.0"
+const Version = "0.4.0"
 
 // PowerState describes whether a VM is on, off, or suspended
 type PowerState string
@@ -482,11 +482,6 @@ func (c *Client) Relocate(vm *VirtualMachine, name, destination string) error {
 			}
 
 			task, err := objFolder.MoveInto(ctx, []types.ManagedObjectReference{vm.Ref})
-
-			// vmrs := types.VirtualMachineRelocateSpec{}
-			// folderMoRef := objFolder.Reference()
-			// vmrs.Folder = &folderMoRef
-			// task, err := vm.VM.Relocate(ctx, vmrs, types.VirtualMachineMovePriorityDefaultPriority)
 			_, err = c.finishTask(ctx, task, err)
 			if err = c.checkErr(ctx, err); err != nil {
 				return err

--- a/cmd/relocate.go
+++ b/cmd/relocate.go
@@ -31,9 +31,9 @@ func createRelocateCommand() *cobra.Command {
 		return nil
 	}
 
-	cc.Flags().StringVarP(&destination, destinationKey, "d", destination, "destination folder for VM")
+	cc.Flags().StringVarP(&destination, destinationKey, "d", destination, "destination folder for VM; if no destination is specified, the VM will not move")
 
-	cc.Flags().StringVarP(&name, nameKey, "n", name, "name of VM; if no name is specified, one will be generated.")
+	cc.Flags().StringVarP(&name, nameKey, "n", name, "name of VM; if no name is specified, the name will not change")
 
 	cc.Flags().BoolVar(&targetIsRef, "targetIsRef", targetIsRef, "TARGET parameter is the target VM's uuid")
 

--- a/cmd/relocate.go
+++ b/cmd/relocate.go
@@ -2,13 +2,12 @@ package cmd
 
 import "github.com/spf13/cobra"
 
-func createRenameCommand() *cobra.Command {
+func createRelocateCommand() *cobra.Command {
 	destination := ""
 	name := ""
 	targetIsRef := false
 
-	cc := NewClientCommand("rename TARGET", "Moves and/or renames the TARGET vm")
-	cc.Aliases = []string{"move"}
+	cc := NewClientCommand("relocate TARGET", "Moves and/or renames the TARGET vm")
 	cc.Args = cobra.ExactArgs(1)
 
 	cc.RunE = func(_ *cobra.Command, params []string) error {

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -1,0 +1,42 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+func createRenameCommand() *cobra.Command {
+	destination := ""
+	name := ""
+	targetIsRef := false
+
+	cc := NewClientCommand("rename TARGET", "Moves and/or renames the TARGET vm")
+	cc.Aliases = []string{"move"}
+	cc.Args = cobra.ExactArgs(1)
+
+	cc.RunE = func(_ *cobra.Command, params []string) error {
+		target := params[0]
+
+		if name == "" && destination == "" {
+			// There is nothing to do here.
+			return nil
+		}
+
+		vm, err := cc.c.FindVM(target, targetIsRef)
+		if err != nil {
+			return err
+		}
+
+		err = cc.c.Relocate(vm, name, destination)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	cc.Flags().StringVarP(&destination, destinationKey, "d", destination, "destination folder for VM")
+
+	cc.Flags().StringVarP(&name, nameKey, "n", name, "name of VM; if no name is specified, one will be generated.")
+
+	cc.Flags().BoolVar(&targetIsRef, "targetIsRef", targetIsRef, "TARGET parameter is the target VM's uuid")
+
+	return &cc.Command
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,7 +24,7 @@ func InitializeCommands() *cobra.Command {
 		createInitCommand(),
 		createNoteCommand(),
 		createPowerCommand(),
-		createRenameCommand(),
+		createRelocateCommand(),
 		createSnapshotCommand(),
 		createTestCommand(),
 		createVersionCommand(),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,7 @@ func InitializeCommands() *cobra.Command {
 		createInitCommand(),
 		createNoteCommand(),
 		createPowerCommand(),
+		createRenameCommand(),
 		createSnapshotCommand(),
 		createTestCommand(),
 		createVersionCommand(),


### PR DESCRIPTION
Adds a command, `relocate`, which will allow the VM to name renamed or moved.