### PR TITLE
Rename with template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /bin
 
 .DS_Store
+release.sh

--- a/client.go
+++ b/client.go
@@ -18,7 +18,7 @@ import (
 )
 
 // Version is the version of the application and API
-const Version = "0.4.0"
+const Version = "0.5.0"
 
 // PowerState describes whether a VM is on, off, or suspended
 type PowerState string

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -25,7 +25,7 @@ func createCloneCommand() *cobra.Command {
 			return err
 		}
 
-		name := cc.generateVMName(name)
+		name = cc.generateVMName(name)
 		destination := viper.GetString(destinationKey)
 		resourcePool := viper.GetString(resourcePoolKey)
 

--- a/cmd/relocate.go
+++ b/cmd/relocate.go
@@ -23,6 +23,10 @@ func createRelocateCommand() *cobra.Command {
 			return err
 		}
 
+		if name != "" {
+			name = cc.generateVMName(name)
+		}
+
 		err = cc.c.Relocate(vm, name, destination)
 		if err != nil {
 			return err


### PR DESCRIPTION
Missed the ability to specify a template string when renaming a VM with the `relocate` command.