### PR TITLE
Note properly puts the note value into the Target

### DIFF
--- a/cmd/note.go
+++ b/cmd/note.go
@@ -26,7 +26,7 @@ func createNoteCommand() *cobra.Command {
 		target := params[0]
 
 		// Get a reader; either Stdin or a specified path
-		note, err := cc.readString(params)
+		note, err := cc.readString(params[1:])
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Previously when Note was used, the TARGET value would also be placed into the Annotation section on the TARGET.